### PR TITLE
Expose AddressFamily of the address.

### DIFF
--- a/src/Enclave.FastPacket/ValueIpAddress.cs
+++ b/src/Enclave.FastPacket/ValueIpAddress.cs
@@ -127,6 +127,11 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
         _addrFamily = addrFamily;
     }
 
+    /// <summary>
+    /// Address family of the address.
+    /// </summary>
+    public AddressFamily AddressFamily => _addrFamily;
+
     /// <inheritdoc />
     public override bool Equals(object? obj)
     {


### PR DESCRIPTION
It would be convenient to expose the underlying address family of a ValueIpAddress.