### PR TITLE
Add ValueIpAddress comparison operators.

### DIFF
--- a/src/Enclave.FastPacket/ValueIpAddress.cs
+++ b/src/Enclave.FastPacket/ValueIpAddress.cs
@@ -64,8 +64,8 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
     /// </summary>
     public static ValueIpAddress CreateIpv6(ReadOnlySpan<byte> address)
     {
-        if (BinaryPrimitives.TryReadUInt64BigEndian(address, out var addr1) &&
-            BinaryPrimitives.TryReadUInt64BigEndian(address.Slice(sizeof(long)), out var addr2))
+        if (BinaryPrimitives.TryReadUInt64BigEndian(address, out var addr2) &&
+            BinaryPrimitives.TryReadUInt64BigEndian(address.Slice(sizeof(ulong)), out var addr1))
         {
             return new ValueIpAddress(AddressFamily.InterNetworkV6, addr1, addr2);
         }
@@ -106,8 +106,8 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
     {
         if (data.Length > 4)
         {
-            BinaryPrimitives.TryReadUInt64BigEndian(data, out _addr1);
-            BinaryPrimitives.TryReadUInt64BigEndian(data.Slice(sizeof(long)), out _addr2);
+            BinaryPrimitives.TryReadUInt64BigEndian(data, out _addr2);
+            BinaryPrimitives.TryReadUInt64BigEndian(data.Slice(sizeof(ulong)), out _addr1);
             _addrFamily = AddressFamily.InterNetworkV6;
         }
         else
@@ -169,8 +169,8 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
         {
             Span<byte> destSpan = stackalloc byte[16];
 
-            BinaryPrimitives.WriteUInt64BigEndian(destSpan, _addr1);
-            BinaryPrimitives.WriteUInt64BigEndian(destSpan.Slice(sizeof(long)), _addr2);
+            BinaryPrimitives.WriteUInt64BigEndian(destSpan, _addr2);
+            BinaryPrimitives.WriteUInt64BigEndian(destSpan.Slice(sizeof(ulong)), _addr1);
 
             return new IPAddress(destSpan);
         }
@@ -196,8 +196,8 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
                 throw new FastPacketException("Destination too small for ipv6", destination);
             }
 
-            BinaryPrimitives.WriteUInt64BigEndian(destination, _addr1);
-            BinaryPrimitives.WriteUInt64BigEndian(destination.Slice(sizeof(long)), _addr2);
+            BinaryPrimitives.WriteUInt64BigEndian(destination, _addr2);
+            BinaryPrimitives.WriteUInt64BigEndian(destination.Slice(sizeof(ulong)), _addr1);
         }
         else
         {
@@ -230,5 +230,81 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
     public static bool operator !=(ValueIpAddress left, ValueIpAddress right)
     {
         return !(left == right);
+    }
+
+    /// <summary>
+    /// Greater than operator.
+    /// </summary>
+    public static bool operator >(ValueIpAddress left, ValueIpAddress right)
+    {
+        if (left._addrFamily != right._addrFamily)
+        {
+            throw new InvalidOperationException("Comparison requires both addresses to be of the same address family.");
+        }
+
+        if (left._addrFamily == AddressFamily.InterNetwork)
+        {
+            return left._addr1 > right._addr1;
+        }
+
+        return left._addr2 > right._addr2 ||
+               (left._addr2 == right._addr2 && left._addr1 > right._addr1);
+    }
+
+    /// <summary>
+    /// Greater than or equal operator.
+    /// </summary>
+    public static bool operator >=(ValueIpAddress left, ValueIpAddress right)
+    {
+        if (left._addrFamily != right._addrFamily)
+        {
+            throw new InvalidOperationException("Comparison requires both addresses to be of the same address family.");
+        }
+
+        if (left._addrFamily == AddressFamily.InterNetwork)
+        {
+            return left._addr1 >= right._addr1;
+        }
+
+        return left._addr2 > right._addr2 ||
+               (left._addr2 == right._addr2 && left._addr1 >= right._addr1);
+    }
+
+    /// <summary>
+    /// Less than operator.
+    /// </summary>
+    public static bool operator <(ValueIpAddress left, ValueIpAddress right)
+    {
+        if (left._addrFamily != right._addrFamily)
+        {
+            throw new InvalidOperationException("Comparison requires both addresses to be of the same address family.");
+        }
+
+        if (left._addrFamily == AddressFamily.InterNetwork)
+        {
+            return left._addr1 < right._addr1;
+        }
+
+        return left._addr2 < right._addr2 ||
+               (left._addr2 == right._addr2 && left._addr1 < right._addr1);
+    }
+
+    /// <summary>
+    /// Less than or equal operator.
+    /// </summary>
+    public static bool operator <=(ValueIpAddress left, ValueIpAddress right)
+    {
+        if (left._addrFamily != right._addrFamily)
+        {
+            throw new InvalidOperationException("Comparison requires both addresses to be of the same address family.");
+        }
+
+        if (left._addrFamily == AddressFamily.InterNetwork)
+        {
+            return left._addr1 <= right._addr1;
+        }
+
+        return left._addr2 < right._addr2 ||
+               (left._addr2 == right._addr2 && left._addr1 <= right._addr1);
     }
 }

--- a/src/Enclave.FastPacket/ValueIpAddress.cs
+++ b/src/Enclave.FastPacket/ValueIpAddress.cs
@@ -2,7 +2,6 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
-using System.Runtime.ConstrainedExecution;
 
 namespace Enclave.FastPacket;
 
@@ -11,8 +10,8 @@ namespace Enclave.FastPacket;
 /// </summary>
 public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
 {
-    private readonly long _addr1;
-    private readonly long _addr2;
+    private readonly ulong _addr1;
+    private readonly ulong _addr2;
     private readonly AddressFamily _addrFamily;
 
     /// <summary>
@@ -50,7 +49,7 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
     /// </summary>
     public static ValueIpAddress CreateIpv4(ReadOnlySpan<byte> address)
     {
-        if (BinaryPrimitives.TryReadInt32BigEndian(address, out var uintAddr))
+        if (BinaryPrimitives.TryReadUInt32BigEndian(address, out var uintAddr))
         {
             return new ValueIpAddress(AddressFamily.InterNetwork, uintAddr, 0);
         }
@@ -65,8 +64,8 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
     /// </summary>
     public static ValueIpAddress CreateIpv6(ReadOnlySpan<byte> address)
     {
-        if (BinaryPrimitives.TryReadInt64BigEndian(address, out var addr1) &&
-            BinaryPrimitives.TryReadInt64BigEndian(address.Slice(sizeof(long)), out var addr2))
+        if (BinaryPrimitives.TryReadUInt64BigEndian(address, out var addr1) &&
+            BinaryPrimitives.TryReadUInt64BigEndian(address.Slice(sizeof(long)), out var addr2))
         {
             return new ValueIpAddress(AddressFamily.InterNetworkV6, addr1, addr2);
         }
@@ -107,20 +106,20 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
     {
         if (data.Length > 4)
         {
-            BinaryPrimitives.TryReadInt64BigEndian(data, out _addr1);
-            BinaryPrimitives.TryReadInt64BigEndian(data.Slice(sizeof(long)), out _addr2);
+            BinaryPrimitives.TryReadUInt64BigEndian(data, out _addr1);
+            BinaryPrimitives.TryReadUInt64BigEndian(data.Slice(sizeof(long)), out _addr2);
             _addrFamily = AddressFamily.InterNetworkV6;
         }
         else
         {
-            BinaryPrimitives.TryReadInt32BigEndian(data, out var uintAddr);
+            BinaryPrimitives.TryReadUInt32BigEndian(data, out var uintAddr);
             _addr1 = uintAddr;
             _addr2 = 0;
             _addrFamily = AddressFamily.InterNetwork;
         }
     }
 
-    private ValueIpAddress(AddressFamily addrFamily, long addr1, long addr2)
+    private ValueIpAddress(AddressFamily addrFamily, ulong addr1, ulong addr2)
     {
         _addr1 = addr1;
         _addr2 = addr2;
@@ -170,8 +169,8 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
         {
             Span<byte> destSpan = stackalloc byte[16];
 
-            BinaryPrimitives.WriteInt64BigEndian(destSpan, _addr1);
-            BinaryPrimitives.WriteInt64BigEndian(destSpan.Slice(sizeof(long)), _addr2);
+            BinaryPrimitives.WriteUInt64BigEndian(destSpan, _addr1);
+            BinaryPrimitives.WriteUInt64BigEndian(destSpan.Slice(sizeof(long)), _addr2);
 
             return new IPAddress(destSpan);
         }
@@ -179,7 +178,7 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
         {
             Span<byte> destSpan = stackalloc byte[4];
 
-            BinaryPrimitives.WriteInt32BigEndian(destSpan, (int)_addr1);
+            BinaryPrimitives.WriteUInt32BigEndian(destSpan, (uint)_addr1);
 
             return new IPAddress(destSpan);
         }
@@ -197,8 +196,8 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
                 throw new FastPacketException("Destination too small for ipv6", destination);
             }
 
-            BinaryPrimitives.WriteInt64BigEndian(destination, _addr1);
-            BinaryPrimitives.WriteInt64BigEndian(destination.Slice(sizeof(long)), _addr2);
+            BinaryPrimitives.WriteUInt64BigEndian(destination, _addr1);
+            BinaryPrimitives.WriteUInt64BigEndian(destination.Slice(sizeof(long)), _addr2);
         }
         else
         {
@@ -207,7 +206,7 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
                 throw new FastPacketException("Destination too small for ipv4", destination);
             }
 
-            BinaryPrimitives.WriteInt32BigEndian(destination, (int)_addr1);
+            BinaryPrimitives.WriteUInt32BigEndian(destination, (uint)_addr1);
         }
     }
 

--- a/tests/Enclave.FastPacket.Tests/ValueIpAddressTests.cs
+++ b/tests/Enclave.FastPacket.Tests/ValueIpAddressTests.cs
@@ -61,4 +61,130 @@ public class ValueIpAddressTests
 
         valueIpv6.Should().NotBe(valueIpv4);
     }
+
+    [Theory]
+    [InlineData("100.1.1.1", "101.1.1.1")]
+    [InlineData("1.255.255.255", "2.0.0.0")]
+    [InlineData("1.1.1.1", "1.1.1.2")]
+    [InlineData("0.0.0.0", "0.0.0.1")]
+    public void CanCompareLessThanIpv4Address(string left, string right)
+    {
+        var ipAddress1 = IPAddress.Parse(left);
+        var ipAddress2 = IPAddress.Parse(right);
+
+        var valueIp1 = ValueIpAddress.Create(ipAddress1);
+        var valueIp2 = ValueIpAddress.Create(ipAddress2);
+        var repeat1 = ValueIpAddress.Create(ipAddress1);
+
+        (valueIp1 < valueIp2).Should().BeTrue();
+        (valueIp2 < valueIp1).Should().BeFalse();
+        (valueIp1 < repeat1).Should().BeFalse();
+
+    }
+
+    [Theory]
+    [InlineData("100.1.1.1", "101.1.1.1")]
+    [InlineData("1.255.255.255", "2.0.0.0")]
+    [InlineData("1.1.1.1", "1.1.1.2")]
+    [InlineData("0.0.0.0", "0.0.0.1")]
+    public void CanCompareLessThanOrEqualIpv4Address(string left, string right)
+    {
+        var ipAddress1 = IPAddress.Parse(left);
+        var ipAddress2 = IPAddress.Parse(right);
+
+        var valueIp1 = ValueIpAddress.Create(ipAddress1);
+        var valueIp2 = ValueIpAddress.Create(ipAddress2);
+        var repeat1 = ValueIpAddress.Create(ipAddress1);
+
+        (valueIp1 <= valueIp2).Should().BeTrue();
+        (valueIp2 <= valueIp1).Should().BeFalse();
+        (valueIp1 <= repeat1).Should().BeTrue();
+
+    }
+
+    [Theory]
+    [InlineData("101.1.1.1", "100.1.1.1")]
+    [InlineData("2.0.0.0", "1.255.255.255")]
+    [InlineData("1.1.1.2", "1.1.1.1")]
+    [InlineData("0.0.0.1", "0.0.0.0")]
+    public void CanCompareGreaterThanIpv4Address(string left, string right)
+    {
+        var ipAddress1 = IPAddress.Parse(left);
+        var ipAddress2 = IPAddress.Parse(right);
+
+        var valueIp1 = ValueIpAddress.Create(ipAddress1);
+        var valueIp2 = ValueIpAddress.Create(ipAddress2);
+        var repeat1 = ValueIpAddress.Create(ipAddress1);
+
+        (valueIp1 > valueIp2).Should().BeTrue();
+        (valueIp2 > valueIp1).Should().BeFalse();
+        (valueIp1 > repeat1).Should().BeFalse();
+
+    }
+
+    [Theory]
+    [InlineData("101.1.1.1", "100.1.1.1")]
+    [InlineData("2.0.0.0", "1.255.255.255")]
+    [InlineData("1.1.1.2", "1.1.1.1")]
+    [InlineData("0.0.0.1", "0.0.0.0")]
+    public void CanCompareGreaterThanOrEqualIpv4Address(string left, string right)
+    {
+        var ipAddress1 = IPAddress.Parse(left);
+        var ipAddress2 = IPAddress.Parse(right);
+
+        var valueIp1 = ValueIpAddress.Create(ipAddress1);
+        var valueIp2 = ValueIpAddress.Create(ipAddress2);
+        var repeat1 = ValueIpAddress.Create(ipAddress1);
+
+        (valueIp1 >= valueIp2).Should().BeTrue();
+        (valueIp2 >= valueIp1).Should().BeFalse();
+        (valueIp1 >= repeat1).Should().BeTrue();
+
+    }
+
+    [Theory]
+    [InlineData("2001:db8:3333:4444:5555:6666:7777:8889", "2001:db8:3333:4444:5555:6666:7777:8888")]
+    [InlineData("2001:db8:3333:4445:5555:6666:7777:8888", "2001:db8:3333:4444:5555:6666:7777:8888")]
+    [InlineData("2002:db8:3333:4444:5555:6666:7777:8888", "2001:db8:3333:4444:5555:6666:7777:8888")]
+    [InlineData("::1", "::")]
+    [InlineData("::18.52.86.121", "::18.52.86.120")]
+    [InlineData("2002::", "2001:db8::1234:5678")]
+    [InlineData("1::", "::1")]
+    public void CanCompareGreaterThanIpv6Address(string left, string right)
+    {
+        var ipAddress1 = IPAddress.Parse(left);
+        var ipAddress2 = IPAddress.Parse(right);
+
+        var valueIp1 = ValueIpAddress.Create(ipAddress1);
+        var valueIp2 = ValueIpAddress.Create(ipAddress2);
+        var repeat1 = ValueIpAddress.Create(ipAddress1);
+
+        (valueIp1 > valueIp2).Should().BeTrue();
+        (valueIp2 > valueIp1).Should().BeFalse();
+        (valueIp1 > repeat1).Should().BeFalse();
+
+    }
+
+    [Theory]
+    [InlineData("2001:db8:3333:4444:5555:6666:7777:8889", "2001:db8:3333:4444:5555:6666:7777:8888")]
+    [InlineData("2001:db8:3333:4445:5555:6666:7777:8888", "2001:db8:3333:4444:5555:6666:7777:8888")]
+    [InlineData("2002:db8:3333:4444:5555:6666:7777:8888", "2001:db8:3333:4444:5555:6666:7777:8888")]
+    [InlineData("::1", "::")]
+    [InlineData("::18.52.86.121", "::18.52.86.120")]
+    [InlineData("2002::", "2001:db8::1234:5678")]
+    [InlineData("1::", "::1")]
+    public void CanCompareGreaterThanOrEqualIpv6Address(string left, string right)
+    {
+        var ipAddress1 = IPAddress.Parse(left);
+        var ipAddress2 = IPAddress.Parse(right);
+
+        var valueIp1 = ValueIpAddress.Create(ipAddress1);
+        var valueIp2 = ValueIpAddress.Create(ipAddress2);
+        var repeat1 = ValueIpAddress.Create(ipAddress1);
+
+        (valueIp1 >= valueIp2).Should().BeTrue();
+        (valueIp2 >= valueIp1).Should().BeFalse();
+        (valueIp1 >= repeat1).Should().BeTrue();
+
+    }
 }


### PR DESCRIPTION
Adds `>` `<` `>=` `<=` operators to ValueIpAddress.

Note I implemented the notion that once converted to little endian the lower 64-bits of the 128-bit IPv6 address is stored in `_addr1` and the upper 64-bits in `_addr2`, which means we need to also swap the reading and writing of the two fields from the big endian byte array.

