### PR TITLE
Write BigInteger as little endian directly.

### DIFF
--- a/src/Enclave.FastPacket/ValueIpAddress.cs
+++ b/src/Enclave.FastPacket/ValueIpAddress.cs
@@ -240,10 +240,10 @@ public readonly struct ValueIpAddress : IEquatable<ValueIpAddress>
         {
             Span<byte> destSpan = stackalloc byte[16];
 
-            BinaryPrimitives.WriteUInt64BigEndian(destSpan, _addr2);
-            BinaryPrimitives.WriteUInt64BigEndian(destSpan.Slice(sizeof(ulong)), _addr1);
+            BinaryPrimitives.WriteUInt64LittleEndian(destSpan, _addr1);
+            BinaryPrimitives.WriteUInt64LittleEndian(destSpan.Slice(sizeof(ulong)), _addr2);
 
-            return new BigInteger(destSpan, isUnsigned: true, isBigEndian: true);
+            return new BigInteger(destSpan, isUnsigned: true, isBigEndian: false);
         }
         else
         {


### PR DESCRIPTION
Since we already store _add1 and _addr2 as little endian, there's no need to first convert to Big Endian, and then have BigInteger convert back to little endian again.

Based on local benchmark it does have a perf benefit.