### PR TITLE
Fix alignment of IPv4 fragmentation flags

### DIFF
--- a/src/Enclave.FastPacket/Ipv4.cs
+++ b/src/Enclave.FastPacket/Ipv4.cs
@@ -12,19 +12,24 @@ namespace Enclave.FastPacket;
 public enum FragmentFlags
 {
     /// <summary>
-    /// Reserved, do not use.
+    /// None
     /// </summary>
-    Reserved = 0x01,
+    None = 0, // When bit shifted, gives [000][0 0000 0000 0000] in binary
+
+    /// <summary>
+    /// More fragments (MF).
+    /// </summary>
+    MoreFragments = 1, // When bit shifted, gives [001][0 0000 0000 0000] in binary
 
     /// <summary>
     /// Don't fragment (DF).
     /// </summary>
-    DontFragment = 0x02,
+    DontFragment = 2, // When bit shifted, gives [010][0 0000 0000 0000] in binary
 
     /// <summary>
-    /// More framgents (MF).
+    /// Reserved, do not use.
     /// </summary>
-    MoreFragments = 0x04,
+    Reserved = 4, // When bit shifted, gives [100][0 0000 0000 0000] in binary
 }
 
 internal ref struct Ipv4Definition

--- a/tests/Enclave.FastPacket.Tests/Ipv4Tests.cs
+++ b/tests/Enclave.FastPacket.Tests/Ipv4Tests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using PacketDotNet;
 using PacketDotNet.Utils;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Xunit;
@@ -113,77 +114,35 @@ public class Ipv4Tests
         icmp.Code.Should().Be(3);
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="standardMtu">Assumed Internet MTU</param>
-    /// <param name="workingMtu">MTU of the encapsualting adapter that causing fragmentation</param>
     [Theory]
-    [InlineData(1500, 1472, 1500)] // Standard MTU, No Encapsulation, No Fragmentation
-    [InlineData(1500, 1472, 1400)] // Adjusted MTU closer to Standard MTU
-    [InlineData(1500, 1472, 1280)] // Standard MTU, Encapsulating MTU
-    [InlineData(1500, 1472, 576)]  // Encapsulation with low MTU
-    [InlineData(9000, 1472, 576)]  // Encapsulation with low MTU
-    public void CanReadIpv4FragmentedPacketWithIcmpPayload(int standardMtu, int icmpPayloadLength, int workingMtu)
+    [InlineData(IpProtocol.Udp, FragmentFlags.DontFragment)]
+    [InlineData(IpProtocol.Icmp, FragmentFlags.MoreFragments)]
+    [InlineData(IpProtocol.Icmp, FragmentFlags.Reserved)]
+    [InlineData(IpProtocol.Tcp, FragmentFlags.None)]
+    public void CanReadIpv4FragmentedPacket(IpProtocol protocol, FragmentFlags fragmentFlags)
     {
-        const int ipHeaderSize = 20; // IPv4 header size
-        const int icmpHeaderSize = 8; // ICMP header size
-        const int ipIdentity = 0x1234;
-
-        int icmpPacketPayloadMaxSize = (workingMtu - ipHeaderSize - icmpHeaderSize) % 8; // Ensure fragment size is a multiple of 8
-
+        var random = new Random();
+        var fragmentOffset = (ushort)random.Next(0, 8191); // (13 bits available for offset)
         var sourceIp = IPAddress.Parse("10.0.0.1");
         var destIp = IPAddress.Parse("127.0.0.2");
 
-        // Build ICMP message
-        var icmpPayload = Enumerable.Range(0, icmpPayloadLength).Select(i => (byte)"ABCD"[i % 4]).ToArray();
-
-        var icmpMessage = new IcmpV4Packet(new ByteArraySegment(icmpPayload.Take(icmpPacketPayloadMaxSize).ToArray()));
-        icmpMessage.TypeCode = IcmpV4TypeCode.EchoReply;
-
-        // Build first IPv4 packet fragment
-        var firstFragment = new IPv4Packet(sourceIp, destIp)
+        var packet = new IPv4Packet(sourceIp, destIp)
         {
-            PayloadPacket = icmpMessage,
-            Protocol = ProtocolType.Icmp,
-            Id = ipIdentity,
-            FragmentFlags = (ushort)FragmentFlags.MoreFragments,
-            FragmentOffset = 0
+            Id = (ushort)random.Next(0, ushort.MaxValue),
+            Protocol = (ProtocolType)protocol,
+            FragmentFlags = (ushort)fragmentFlags,
+            FragmentOffset = fragmentOffset
         };
 
-        // Build second IPv4 packet fragment
-        var secondFragment = new IPv4Packet(sourceIp, destIp)
-        {
-            PayloadData = icmpPayload.Skip(icmpPacketPayloadMaxSize).Take(icmpPayload.Length - icmpPacketPayloadMaxSize).ToArray(),
-            Protocol = ProtocolType.Icmp,
-            Id = ipIdentity,
-            FragmentFlags = 0,
-            FragmentOffset = icmpPacketPayloadMaxSize / 8 // Offset in 8-byte units
-        };
+        var packetData = packet.Bytes;
 
-        // Check first packet fragment
-        var myIp1 = new Ipv4PacketSpan(firstFragment.Bytes);
+        // Parse the packet
+        var myIp = new ReadOnlyIpv4PacketSpan(packetData);
 
-        myIp1.Protocol.Should().Be(IpProtocol.Icmp);
-        myIp1.Source.ToIpAddress().Should().Be(sourceIp);
-        myIp1.Destination.ToIpAddress().Should().Be(destIp);
-        myIp1.FragmentFlags.Should().Be(FragmentFlags.MoreFragments);
-        myIp1.FragmentOffset.Should().Be(0);
-        
-        var icmp1 = new Icmpv4PacketSpan(myIp1.Payload);
-
-        icmp1.Type.Should().Be(Icmpv4Types.EchoReply);
-        icmp1.Code.Should().Be(0); // 0 is the code for EchoReply.
-        icmp1.Data.Length.Should().Be(icmpPacketPayloadMaxSize - 8);
-
-        // Check second packet fragment
-        var myIp2 = new Ipv4PacketSpan(secondFragment.Bytes);
-
-        myIp2.Protocol.Should().Be(IpProtocol.Icmp);
-        myIp2.Source.ToIpAddress().Should().Be(sourceIp);
-        myIp2.Destination.ToIpAddress().Should().Be(destIp);
-        myIp2.FragmentFlags.Should().Be(FragmentFlags.None);
-        myIp2.FragmentOffset.Should().Be((ushort)(icmpPacketPayloadMaxSize / 8));
-        myIp2.Payload.Length.Should().Be(icmpPayloadLength - icmpPacketPayloadMaxSize); // Remaining payload size (without ICMP header).
+        myIp.Protocol.Should().Be(protocol);
+        myIp.Source.ToIpAddress().Should().Be(sourceIp);
+        myIp.Destination.ToIpAddress().Should().Be(destIp);
+        myIp.FragmentFlags.Should().Be(fragmentFlags);
+        myIp.FragmentOffset.Should().Be(fragmentOffset);
     }
 }

--- a/tests/Enclave.FastPacket.Tests/Ipv4Tests.cs
+++ b/tests/Enclave.FastPacket.Tests/Ipv4Tests.cs
@@ -2,8 +2,6 @@ using FluentAssertions;
 using PacketDotNet;
 using PacketDotNet.Utils;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using Xunit;
 


### PR DESCRIPTION
It appears that the bit field alignment on IPv4 fragmentation field flags is not correct. This PR fixes that.